### PR TITLE
Refactor and optimize option handling and download progress

### DIFF
--- a/CommandLineApp/CommandLineApp.cs
+++ b/CommandLineApp/CommandLineApp.cs
@@ -1,4 +1,3 @@
-using System.CommandLine;
 using dis.CommandLineApp.Conversion;
 using dis.CommandLineApp.Interfaces;
 using dis.CommandLineApp.Models;
@@ -110,39 +109,5 @@ public sealed class CommandLineApp : ICommandLineApp
             Directory.Delete(d, true);
             _logger.Verbose("Deleted temp dir: {Dir}", d);
         });
-    }
-
-    public ParsedOptions ParseOptions(ParseResult result, UnParsedOptions unparsed)
-    {
-        var inputs = result.GetResult(unparsed.Inputs)?.GetValueOrDefault<string[]>()!;
-        var output = result.GetResult(unparsed.Output)?.GetValueOrDefault<string>()!;
-        var multiThread = result.GetResult(unparsed.MultiThread)?.GetValueOrDefault<int>() ?? 0;
-        var crf = result.GetResult(unparsed.Crf)?.GetValueOrDefault<int>() ?? 0;
-        var resolution = result.GetResult(unparsed.Resolution)?.GetValueOrDefault<string>()!;
-        var videoCodec = result.GetResult(unparsed.VideoCodec)?.GetValueOrDefault<string>()!;
-        var trim = result.GetResult(unparsed.Trim)?.GetValueOrDefault<string>()!;
-        var audioBitrate = result.GetResult(unparsed.AudioBitrate)?.GetValueOrDefault<int>() ?? 0;
-        var randomFileName = result.GetResult(unparsed.RandomFileName)?.GetValueOrDefault<bool>() ?? false;
-        var keepWaterMark = result.GetResult(unparsed.KeepWatermark)?.GetValueOrDefault<bool>() ?? false;
-        var sponsorBlock = result.GetResult(unparsed.SponsorBlock)?.GetValueOrDefault<bool>() ?? false;
-        var verbose = result.GetResult(unparsed.Verbose)?.GetValueOrDefault<bool>() ?? false;
-
-        ParsedOptions parsed = new()
-        {
-            Inputs = inputs,
-            Output = output,
-            MultiThread = multiThread,
-            Crf = crf,
-            Resolution = resolution,
-            VideoCodec = videoCodec,
-            Trim = trim,
-            AudioBitrate = audioBitrate,
-            RandomFileName = randomFileName,
-            KeepWatermark = keepWaterMark,
-            SponsorBlock = sponsorBlock,
-            Verbose = verbose
-        };
-
-        return parsed;
     }
 }

--- a/CommandLineApp/CommandLineOptions.cs
+++ b/CommandLineApp/CommandLineOptions.cs
@@ -13,108 +13,59 @@ public sealed class CommandLineOptions : ICommandLineOptions
         _validator = validator;
     }
 
-    public (CliConfiguration, UnParsedOptions) GetCommandLineOptions()
+    public (CliConfiguration, ParsedOptions) GetCommandLineOptions()
     {
-        CliRootCommand rootCommand = new();
-
-        CliOption<bool> randomFileName = new("input", "-rd", "--random")
+        CliRootCommand rootCommand = new()
         {
-            Description = "Generate a random file name",
+            TreatUnmatchedTokensAsErrors = true
         };
 
-        CliOption<bool> keepWatermark = new("watermark", "-k", "--keep")
-        {
-            Description = "Keep the watermark",
-        };
-
-        CliOption<bool> sponsorBlock = new("sponsorBlock", "-sb", "--sponsor")
-        {
-            Description = "Remove sponsors segments from the video",
-        };
-
-        CliOption<string[]> input = new("input", "-i", "--input")
-        {
-            Description = "A path to a video link or file",
-            AllowMultipleArgumentsPerToken = true,
-            Required = true,
-            Validators = { _validator.Inputs }
-        };
-
-        CliOption<string> output = new("output", "-o", "--output")
-        {
-            Description = "Directory to save the compressed video to",
-            DefaultValueFactory = _ => Environment.CurrentDirectory,
-            Validators = { _validator.Output }
-        };
-
-        CliOption<string> videoCodec = new("videoCodec", "-vc", "--video-codec")
-        {
-            Description = "Video codec",
-            Validators = { _validator.VideoCodec }
-        };
-
-        CliOption<int> multiThread = new("multiThread", "-mt", "--multi-thread")
-        {
-            Description = "Number of threads to use",
-            DefaultValueFactory = _ => 1,
-            Validators = { _validator.MultiThread }
-        };
-
-        CliOption<int> crf = new("crf", "-c", "--crf")
-        {
-            Description = "CRF value",
-            DefaultValueFactory = _ => 29,
-            Validators = { _validator.Crf }
-        };
-
-        CliOption<string> resolution = new("resolution", "-r", "--resolution")
-        {
-            Description = "Resolution",
-            Validators = { _validator.Resolution }
-        };
-
-        CliOption<string> trim = new("trim", "-t", "--trim")
-        {
-            Description = "Trim a video from a website",
-            Validators = { _validator.Trim }
-        };
-
-        CliOption<int> audioBitrate = new("audioBitrate", "-ab", "--audio-bitrate")
-        {
-            Description = "Audio bitrate",
-            Validators = { _validator.AudioBitRate }
-        };
-
-        CliOption<bool> verbose = new("verbose", "--verbose")
-        {
-            Description = "Verbose output",
-            DefaultValueFactory = _ => false
-        };
-
-        rootCommand.TreatUnmatchedTokensAsErrors = true;
+        UnParsedOptions unParsedOptions = new(_validator);
 
         CliOption[] options =
         {
-            input,
-            output,
-            multiThread,
-            crf,
-            resolution,
-            videoCodec,
-            trim,
-            audioBitrate,
-            randomFileName,
-            keepWatermark,
-            sponsorBlock,
-            verbose,
+            unParsedOptions.Inputs,
+            unParsedOptions.Output,
+            unParsedOptions.Resolution,
+            unParsedOptions.VideoCodec,
+            unParsedOptions.Trim,
+            unParsedOptions.MultiThread,
+            unParsedOptions.Crf,
+            unParsedOptions.AudioBitrate,
+            unParsedOptions.RandomFileName,
+            unParsedOptions.KeepWatermark,
+            unParsedOptions.SponsorBlock,
+            unParsedOptions.Verbose
         };
 
         foreach (var option in options)
             rootCommand.Add(option);
 
-        UnParsedOptions o = new()
+        CliConfiguration config = new(rootCommand);
+        var configResult = config.Parse(Environment.GetCommandLineArgs());
+        var parsedOptions = ParseOptions(configResult, unParsedOptions);
+
+        return (config, parsedOptions);
+    }
+
+    private static ParsedOptions ParseOptions(ParseResult result, UnParsedOptions unparsed)
+    {
+        var inputs = result.GetResult(unparsed.Inputs)?.GetValueOrDefault<string[]>()!;
+        var output = result.GetResult(unparsed.Output)?.GetValueOrDefault<string>()!;
+        var multiThread = result.GetResult(unparsed.MultiThread)?.GetValueOrDefault<int>() ?? 0;
+        var crf = result.GetResult(unparsed.Crf)?.GetValueOrDefault<int>() ?? 0;
+        var resolution = result.GetResult(unparsed.Resolution)?.GetValueOrDefault<string>()!;
+        var videoCodec = result.GetResult(unparsed.VideoCodec)?.GetValueOrDefault<string>()!;
+        var trim = result.GetResult(unparsed.Trim)?.GetValueOrDefault<string>()!;
+        var audioBitrate = result.GetResult(unparsed.AudioBitrate)?.GetValueOrDefault<int>() ?? 0;
+        var randomFileName = result.GetResult(unparsed.RandomFileName)?.GetValueOrDefault<bool>() ?? false;
+        var keepWaterMark = result.GetResult(unparsed.KeepWatermark)?.GetValueOrDefault<bool>() ?? false;
+        var sponsorBlock = result.GetResult(unparsed.SponsorBlock)?.GetValueOrDefault<bool>() ?? false;
+        var verbose = result.GetResult(unparsed.Verbose)?.GetValueOrDefault<bool>() ?? false;
+
+        ParsedOptions parsed = new()
         {
-            Inputs = input,
+            Inputs = inputs,
             Output = output,
             MultiThread = multiThread,
             Crf = crf,
@@ -123,13 +74,11 @@ public sealed class CommandLineOptions : ICommandLineOptions
             Trim = trim,
             AudioBitrate = audioBitrate,
             RandomFileName = randomFileName,
-            KeepWatermark = keepWatermark,
+            KeepWatermark = keepWaterMark,
             SponsorBlock = sponsorBlock,
-            Verbose = verbose,
+            Verbose = verbose
         };
 
-        CliConfiguration config = new(rootCommand);
-
-        return (config, o);
+        return parsed;
     }
 }

--- a/CommandLineApp/Downloaders/VideoDownloaderBase.cs
+++ b/CommandLineApp/Downloaders/VideoDownloaderBase.cs
@@ -49,7 +49,6 @@ public abstract class VideoDownloaderBase : IVideoDownloader
         var dlResult = await DownloadVideo(fetch);
         if (dlResult is null)
             return new DownloadResult(null, null);
-        Console.WriteLine();
 
         // Post-download custom logic
         var postDownload = await PostDownload(fetch);
@@ -82,6 +81,7 @@ public abstract class VideoDownloaderBase : IVideoDownloader
         var download = await YoutubeDl.RunVideoDownload(Query.Uri.ToString(),
             overrideOptions: Query.OptionSet,
             progress: _downloadProgress);
+        Console.WriteLine(); // New line after download progress
         Logger.Verbose("Finished downloading {Title}", fetch.Data.Title);
         if (download.Success)
             return download;
@@ -139,7 +139,8 @@ public abstract class VideoDownloaderBase : IVideoDownloader
     {
         /*
          * The download section string is split into two parts using '-' as a separator.
-         * The '*' character, which is used as a regex symbol for "yt-dlp", is not relevant for our parsing and is therefore removed.
+         * The '*' character, which is used as a regex symbol for "yt-dlp",
+         * it is not relevant for our parsing and is therefore removed.
          * The start time is always on the left side of the split, and the end time is always on the right side.
          */
 

--- a/CommandLineApp/Interfaces/ICommandLineApp.cs
+++ b/CommandLineApp/Interfaces/ICommandLineApp.cs
@@ -1,4 +1,3 @@
-using System.CommandLine;
 using dis.CommandLineApp.Models;
 
 namespace dis.CommandLineApp.Interfaces;
@@ -6,6 +5,4 @@ namespace dis.CommandLineApp.Interfaces;
 public interface ICommandLineApp
 {
     Task Handler(ParsedOptions o);
-
-    ParsedOptions ParseOptions(ParseResult result, UnParsedOptions unparsed);
 }

--- a/CommandLineApp/Interfaces/ICommandLineOptions.cs
+++ b/CommandLineApp/Interfaces/ICommandLineOptions.cs
@@ -5,5 +5,5 @@ namespace dis.CommandLineApp.Interfaces;
 
 public interface ICommandLineOptions
 {
-    (CliConfiguration, UnParsedOptions) GetCommandLineOptions();
+    (CliConfiguration, ParsedOptions) GetCommandLineOptions();
 }

--- a/CommandLineApp/Models/ParsedOptions.cs
+++ b/CommandLineApp/Models/ParsedOptions.cs
@@ -2,8 +2,8 @@ namespace dis.CommandLineApp.Models;
 
 public sealed class ParsedOptions
 {
-    public required string[] Inputs { get; init; }
-    public required string Output { get; init; }
+    public string[] Inputs { get; init; } = null!;
+    public string Output { get; init; } = null!;
     public string? Resolution { get; init; }
     public string? VideoCodec { get; init; }
     public string? Trim { get; init; }
@@ -15,5 +15,5 @@ public sealed class ParsedOptions
     public bool RandomFileName { get; init; }
     public bool KeepWatermark { get; init; }
     public bool SponsorBlock { get; init; }
-    public bool Verbose { get; set; }
+    public bool Verbose { get; init; }
 }

--- a/CommandLineApp/Models/UnParsedOptions.cs
+++ b/CommandLineApp/Models/UnParsedOptions.cs
@@ -1,22 +1,114 @@
 using System.CommandLine;
+using dis.CommandLineApp.Interfaces;
 
 namespace dis.CommandLineApp.Models;
 
 public sealed class UnParsedOptions
 {
-    public required CliOption<string[]> Inputs { get; init; }
-    public required CliOption<string> Output { get; init; }
-    public CliOption<string> Resolution { get; init; } = null!;
-    public CliOption<string> VideoCodec { get; init; } = null!;
-    public CliOption<string> Trim { get; init; } = null!;
+    public readonly CliOption<string[]> Inputs;
 
-    public CliOption<int> MultiThread { get; init; } = null!;
-    public CliOption<int> Crf { get; init; } = null!;
-    public CliOption<int> AudioBitrate { get; init; } = null!;
+    public readonly CliOption<string> Output;
+    public readonly CliOption<string> Resolution;
+    public readonly CliOption<string> VideoCodec;
+    public readonly CliOption<string> Trim;
 
-    public CliOption<bool> RandomFileName { get; init; } = null!;
-    public CliOption<bool> KeepWatermark { get; init; } = null!;
-    public CliOption<bool> SponsorBlock { get; init; } = null!;
+    public readonly CliOption<int> MultiThread;
+    public readonly CliOption<int> Crf;
+    public readonly CliOption<int> AudioBitrate;
 
-    public CliOption<bool> Verbose { get; set; } = null!;
+    public readonly CliOption<bool> RandomFileName;
+    public readonly CliOption<bool> KeepWatermark;
+    public readonly CliOption<bool> SponsorBlock;
+
+    public readonly CliOption<bool> Verbose;
+
+    public UnParsedOptions(ICommandLineValidator validator)
+    {
+        Inputs = new CliOption<string[]>("input", "-i", "--input")
+        {
+            Description = "A path to a video link or file",
+            AllowMultipleArgumentsPerToken = true,
+            Required = true,
+            Validators = { validator.Inputs }
+        };
+
+        Output = new CliOption<string>("output", "-o", "--output")
+        {
+            Description = "Directory to save the compressed video to",
+            DefaultValueFactory = _ => Environment.CurrentDirectory,
+            Validators = { validator.Output }
+        };
+
+        Resolution = new CliOption<string>("resolution", "-r", "--resolution")
+        {
+            Description = "Video resolution",
+            Validators = { validator.Resolution }
+        };
+
+        VideoCodec = new CliOption<string>("videoCodec", "-vc", "--video-codec")
+        {
+            Description = "Video codec",
+            Validators = { validator.VideoCodec }
+        };
+
+        Trim = new CliOption<string>("trim", "-t", "--trim")
+        {
+            Description = """
+                          Trim the video
+                          Format: ss.ms-mm.ms
+                          Example: 12.35-67.40
+                          """,
+            Validators = { validator.Trim }
+        };
+
+        MultiThread = new CliOption<int>("multiThread", "-mt", "--multi-thread")
+        {
+            Description = "Number of threads to use",
+            DefaultValueFactory = _ => 1,
+            Validators = { validator.MultiThread }
+        };
+
+        Crf = new CliOption<int>("crf", "-c", "--crf")
+        {
+            Description = """
+                          Constant Rate Factor (CRF)
+                          Higher values mean lower quality
+                          Lower values mean higher quality
+                          You should use a sane value between 22 and 38
+                          """,
+            DefaultValueFactory = _ => 22,
+            Validators = { validator.Crf }
+        };
+
+        AudioBitrate = new CliOption<int>("audioBitrate", "-ab", "--audio-bitrate")
+        {
+            Description = "Audio bitrate",
+            DefaultValueFactory = _ => 128,
+            Validators = { validator.AudioBitRate }
+        };
+
+        RandomFileName = new CliOption<bool>("randomFileName", "-rfn", "--random-file-name")
+        {
+            Description = "The output file name will be random file name",
+            DefaultValueFactory = _ => false
+        };
+
+        KeepWatermark = new CliOption<bool>("keepWatermark", "-kw", "--keep-watermark")
+        {
+            Description = "Keep watermark for TikTok",
+            DefaultValueFactory = _ => false
+        };
+
+        SponsorBlock = new CliOption<bool>("sponsorBlock", "-sb", "--sponsor-block")
+        {
+            Description = "Use sponsor block for YouTube",
+            DefaultValueFactory = _ => false
+        };
+
+        Verbose = new CliOption<bool>("verbose", "--verbose")
+        {
+            Description = "Verbose output",
+            DefaultValueFactory = _ => false
+        };
+    }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -32,9 +32,7 @@ var services = serviceScope.ServiceProvider;
 var commandLineApp = services.GetRequiredService<ICommandLineApp>();
 var commandLineOptions = services.GetRequiredService<ICommandLineOptions>();
 
-var (config, unParsedOptions) = commandLineOptions.GetCommandLineOptions();
-var parseResult = config.Parse(args);
-var parsedOptions = commandLineApp.ParseOptions(parseResult, unParsedOptions);
+var (config, parsedOptions) = commandLineOptions.GetCommandLineOptions();
 
 // Set the MinimumLevel property of the switch based on the argument value
 levelSwitch.MinimumLevel = parsedOptions.Verbose ? LogEventLevel.Verbose : // Set the minimum level to Verbose

--- a/dis.csproj
+++ b/dis.csproj
@@ -1,21 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-	<Version>8.1.0</Version>
-    </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <Version>8.1.0</Version>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0-rc.1.23419.4" />
-      <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
-      <PackageReference Include="Serilog.Expressions" Version="4.0.0-dev-00137" />
-      <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.23407.1" />
-      <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.23407.1" />
-      <PackageReference Include="Xabe.FFmpeg" Version="5.2.6" />
-      <PackageReference Include="YoutubeDLSharp" Version="1.0.0" />
-    </ItemGroup>
-    
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0-rc.1.23419.4" />
+    <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
+    <PackageReference Include="Serilog.Expressions" Version="4.0.0-dev-00137" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.23407.1" />
+    <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.23407.1" />
+    <PackageReference Include="Xabe.FFmpeg" Version="5.2.6" />
+    <PackageReference Include="YoutubeDLSharp" Version="1.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/dis.csproj
+++ b/dis.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>8.1.0</Version>
+    <Version>8.1.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/nuget.config
+++ b/nuget.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="dnceng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
+    <add key="dnceng"
+      value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
The main changes are:

- Moved the creation of `CliOption<T>` to `UnParsedOptions.cs` via constructor.
- Changed `GetCommandLineOptions()` to initialize both `UnParsedOptions` and `ParsedOptions`.
- `GetCommandLineOptions()` now returns `ParsedOptions` instead of `UnParsedOptions`.
- `ParseOptions()` is now a private static method in `GetCommandLineOptions()`.